### PR TITLE
chore(wallet standard): Update Serialize Javascript Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,9 +1881,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -3439,7 +3439,7 @@
             "requires": {
                 "@babel/code-frame": "^7.10.4",
                 "jest-worker": "^26.2.1",
-                "serialize-javascript": "^4.0.0",
+                "serialize-javascript": "6.0.2",
                 "terser": "^5.0.0"
             }
         },
@@ -3476,9 +3476,9 @@
             "dev": true
         },
         "serialize-javascript": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
         "shx": "0.3.4",
         "typescript": "4.9.5"
     },
+    "overrides": {
+        "serialize-javascript": "6.0.2"
+    },
     "version": "0.0.14"
 }


### PR DESCRIPTION
This should fix `serialize-javascript` dependency security alert https://github.com/brave/wallet-standard-brave/security/dependabot/10