### PR TITLE
fix: repair rollup build and add CI build job to catch regressions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,3 +13,17 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Audit packages
         run: npm audit --audit-level moderate
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import nodeResolve from '@rollup/plugin-node-resolve';
 
 const extensions = ['.js', '.ts'];


### PR DESCRIPTION
- Import `terser` from `@rollup/plugin-terser`. The dep was renamed in #91 but `rollup.config.js` still imported the removed `rollup-plugin-terser`.
- Add a `build` job to the PR workflow. CI only ran `npm audit`, so the broken build went unnoticed.