### PR TITLE
ci: add npm publish workflow and package integrity checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build
+        run: npm run build
+      - name: Assert iife bundle exists
+        run: test -s lib/index.iife.min.js
+      - name: Verify package version matches release tag
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG=${GITHUB_REF_NAME#v}
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "package.json version ($PKG_VERSION) does not match release tag ($TAG)"
+            exit 1
+          fi
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: Build
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -24,6 +24,36 @@ jobs:
           node-version: 20
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Build
         run: npm run build
+      - name: Assert iife bundle exists
+        run: test -s lib/index.iife.min.js
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Build
+        run: npm run build
+      - name: Assert iife bundle exists
+        run: test -s lib/index.iife.min.js
+      - name: Pack
+        run: |
+          PKG=$(npm pack --silent)
+          echo "PKG_TARBALL=$PWD/$PKG" >> "$GITHUB_ENV"
+      - name: Smoke test packaged module (ESM + CJS)
+        run: |
+          mkdir -p "$RUNNER_TEMP/smoke"
+          cd "$RUNNER_TEMP/smoke"
+          npm init -y >/dev/null
+          npm install --ignore-scripts "$PKG_TARBALL" >/dev/null
+          node --input-type=module -e "import('@brave/wallet-standard-brave').then(m => { if (typeof m.initialize !== 'function') throw new Error('ESM export \"initialize\" missing'); console.log('ESM import OK'); })"
+          node -e "const m = require('@brave/wallet-standard-brave'); if (typeof m.initialize !== 'function') throw new Error('CJS export \"initialize\" missing'); console.log('CJS require OK');"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # wallet-standard-brave
 
+[![Build](https://github.com/brave/wallet-standard-brave/actions/workflows/pull_request.yml/badge.svg)](https://github.com/brave/wallet-standard-brave/actions/workflows/pull_request.yml)
+[![CodeQL](https://github.com/brave/wallet-standard-brave/actions/workflows/codeql.yml/badge.svg)](https://github.com/brave/wallet-standard-brave/actions/workflows/codeql.yml)
+[![npm](https://img.shields.io/npm/v/@brave/wallet-standard-brave)](https://www.npmjs.com/package/@brave/wallet-standard-brave)
+
 This is modified from wallet-standard `ghost` example wallet following
 https://github.com/solana-labs/wallet-standard/blob/master/WALLET.md
 
@@ -7,11 +11,10 @@ https://github.com/solana-labs/wallet-standard/blob/master/WALLET.md
 
 Please file issues related to this repository in [Brave Browser repository](https://github.com/brave/brave-browser).
 
-## Bumping this package
+## Releasing a new version
 
-To bump this package do the following:
-1. Update the dependencies to fix the alerts
-2. run `npm run build`. Make sure the lib directory correctly generates an `index.iife.min.js` file, or it won't work with brave-core
-3. run `npm run fmt`
-4. push the updated version to github and merge to master, then tag it properly
-5. Publish that version to npm and then use it in brave-core
+Publishing to npm is automated by the [Publish workflow](.github/workflows/publish.yml),
+which runs with provenance on every GitHub release. To cut a release, bump the
+`version` in `package.json`, merge to `master`, then create a GitHub release with a
+matching `v<version>` tag (the workflow fails on a mismatch). Once published, update
+brave-core to use the new version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@brave/wallet-standard-brave",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@brave/wallet-standard-brave",
-            "version": "0.0.16",
+            "version": "0.0.17",
             "license": "Apache-2.0",
             "dependencies": {
                 "@solana/wallet-standard-features": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "clean": "shx mkdir -p lib && shx rm -rf lib",
         "tsc": "tsc --build --verbose tsconfig.all.json",
         "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-        "build": "npm run clean && npm run tsc && npm run package; rollup -c"
+        "build": "npm run clean && npm run tsc && npm run package && rollup -c"
     },
     "dependencies": {
         "@solana/wallet-standard-features": "^1.3.0",
@@ -51,5 +51,5 @@
         "serialize-javascript": "7.0.5",
         "uuid": "11.1.1"
     },
-    "version": "0.0.16"
+    "version": "0.0.17"
 }


### PR DESCRIPTION
## Summary
Until [recently](https://github.com/brave/wallet-standard-brave/commit/4d92c8bed61f31bfde1a8731824ca6bb41256767), CI never ran `npm run build` at all. This PR builds on that change: it adds checks on the bundle brave-core consumes so we can't publish something broken, and it automates npm publishing so releases no longer go out by hand from a laptop.

Also fixed a subtle gap where `; rollup -c` let the build pass even when `tsc` failed. Switched to `&& rollup -c`, which means type errors now fail the build.